### PR TITLE
Add docker-compose setup and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+IMAP_HOST=imap.example.com
+IMAP_PORT=993
+IMAP_SSL=true
+
+# SMTP configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_USER=username
+SMTP_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cgi-bin/openwebmail/etc/*.log
 
 data/openwebmail/tmp/
 data/openwebmail/uploads/
+
+# Local environment files
+.env

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ docker run -p 8080:80 openwebmail
 The application will then be available at
 `http://localhost:8080/openwebmail`.
 
+### Docker Compose
+
+An example environment file is provided to make configuration easier. Copy
+`.env.example` to `.env` and adjust the values for your IMAP and SMTP server.
+
+Build and start the service with:
+
+```sh
+docker-compose up --build
+```
+
+The web interface will be available at `http://localhost:8080/openwebmail`.
+
 ## Links
 
 <http://openwebmail.acatysmoof.com/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  openwebmail:
+    build: .
+    ports:
+      - "8080:80"
+    environment:
+      - IMAP_HOST=${IMAP_HOST}
+      - IMAP_PORT=${IMAP_PORT}
+      - IMAP_SSL=${IMAP_SSL}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}


### PR DESCRIPTION
## Summary
- provide `.env.example` with IMAP and SMTP placeholders
- add `docker-compose.yml` for easier container startup
- ignore local `.env` files
- document new docker-compose workflow in README

## Testing
- `docker-compose --version` *(fails: command not found)*
- `docker compose version` *(fails: command not found)*