### PR TITLE
Add IMAP authentication module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 IMAP_HOST=imap.example.com
 IMAP_PORT=993
 IMAP_SSL=true
+IMAP_USER=username
+IMAP_PASSWORD=password
 
 # SMTP configuration
 SMTP_HOST=smtp.example.com

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ tests with:
 prove -l
 ```
 
+## IMAP Support
+
+An authentication module for remote IMAP servers is provided as
+`auth_imap.pl`.  Enable it by setting `auth_module` in
+`cgi-bin/openwebmail/etc/openwebmail.conf` and define the server
+parameters `authimap_server`, `authimap_port` and `authimap_usessl`.
+The helper script `misc/test/authtest.pl` can be used to verify a user
+against the configured IMAP server:
+
+```sh
+perl misc/test/authtest.pl auth_imap.pl username password
+```
+
 ## Docker Setup
 
 A `Dockerfile` is provided for running OpenWebMail on a modern Ubuntu

--- a/cgi-bin/openwebmail/auth/auth_imap.pl
+++ b/cgi-bin/openwebmail/auth/auth_imap.pl
@@ -1,0 +1,95 @@
+package ow::auth_imap;
+# auth_imap.pl - authenticate user with IMAP server
+
+use strict;
+use warnings FATAL => 'all';
+
+use IO::Socket;
+
+require "modules/tool.pl";
+
+my %conf;
+if (($_=ow::tool::find_configfile('etc/auth_imap.conf', 'etc/defaults/auth_imap.conf')) ne '') {
+   my ($ret, $err)=ow::tool::load_configfile($_, \%conf);
+   die $err if $ret<0;
+}
+
+my $effectiveuser=$conf{'effectiveuser'} || 'nobody';
+
+sub get_userinfo {
+   my ($r_config, $user)=@_;
+   return (-2, 'User is null') if $user eq '';
+
+   my ($uid,$gid,$realname,$homedir)=(getpwnam($effectiveuser))[2,3,6,7];
+   return(-4, "User $user doesn't exist") if $uid eq '';
+
+   while (my @gr=getgrent()) {
+      $gid .= ' '.$gr[2] if ($gr[3]=~/\b$effectiveuser\b/ && $gid!~/\b$gr[2]\b/);
+   }
+   $realname=(split(/,/, $realname))[0];
+   $homedir="/export$homedir" if (-d "/export$homedir");
+
+   return(0, '', $realname, $uid, $gid, $homedir);
+}
+
+sub get_userlist {
+   my $r_config=$_[0];
+   return(-1, 'userlist() is not available in auth_imap.pl');
+}
+
+sub check_userpassword {
+   my ($r_config, $user, $password)=@_;
+   return (-2, 'User or password is null') if $user eq '' || $password eq '';
+
+   my ($server,$port,$usessl)=(ow::tool::untaint(${$r_config}{'authimap_server'}),
+                               ow::tool::untaint(${$r_config}{'authimap_port'}),
+                               ${$r_config}{'authimap_usessl'});
+
+   my $socket;
+   eval {
+      alarm 30; local $SIG{ALRM}=sub{die "alarm\n"};
+      if ($usessl && ow::tool::has_module('IO/Socket/SSL.pm')) {
+         $socket=IO::Socket::SSL->new(PeerAddr=>$server, PeerPort=>$port, Proto=>'tcp');
+      } else {
+         $port=143 if $usessl && $port==993;
+         $socket=IO::Socket::INET->new(PeerAddr=>$server, PeerPort=>$port, Proto=>'tcp');
+      }
+      alarm 0;
+   };
+   return (-3, "imap server $server:$port connect error") if $@ or !$socket;
+
+   eval {
+      alarm 10; local $SIG{ALRM}=sub{die "alarm\n"};
+      $socket->autoflush(1);
+      $_=<$socket>;
+      alarm 0;
+   };
+   return (-3, "imap server $server:$port server not ready") if $@ or !/^\* OK/;
+
+   my @result;
+   my $tag='A0001';
+   return (-4, "imap server $server:$port bad login")
+      unless sendcmd($socket, "$tag LOGIN $user $password\r\n", \@result)
+             && $result[0] =~ /^$tag/ && $result[1] =~ /^OK/i;
+
+   sendcmd($socket, "$tag LOGOUT\r\n", \@result);
+   close $socket;
+   return (0,'');
+}
+
+sub change_userpassword {
+   my ($r_config, $user, $oldpassword, $newpassword)=@_;
+   return (-2, 'User or password is null') if $user eq '' || $oldpassword eq '' || $newpassword eq '';
+   return (-1, 'change_password() is not available in auth_imap.pl');
+}
+
+sub sendcmd {
+   my ($socket,$cmd,$r_result)=@_;
+   print $socket $cmd;
+   my $line=<$socket>;
+   return 0 unless defined $line;
+   @$r_result = split(/\s+/, $line);
+   return 1;
+}
+
+1;

--- a/cgi-bin/openwebmail/etc/defaults/auth_imap.conf
+++ b/cgi-bin/openwebmail/etc/defaults/auth_imap.conf
@@ -1,0 +1,20 @@
+#
+# config file for auth_imap.pl
+#
+# This module allows authentication against a remote IMAP server. It
+# behaves similarly to auth_pop3.pl and is intended for installations
+# where user accounts reside on a separate mail host or are managed as
+# virtual users.
+#
+# To use it, set the following options in openwebmail.conf:
+#    auth_module        auth_imap.pl
+#    authimap_server    imap server for authentication (default: localhost)
+#    authimap_port      143
+#    authimap_usessl    no
+#
+# effectiveuser
+# -----------------------------------------------------------------------
+# the effectiveuser that will be used for all users authenticated by
+# the auth_imap module
+
+effectiveuser   nobody

--- a/cgi-bin/openwebmail/etc/defaults/openwebmail.conf
+++ b/cgi-bin/openwebmail/etc/defaults/openwebmail.conf
@@ -207,6 +207,10 @@ authpop3_port		110
 authpop3_getmail	no
 authpop3_delmail	yes
 authpop3_usessl		no
+# IMAP authentication settings
+authimap_server		 localhost
+authimap_port		 143
+authimap_usessl		 no
 
 loginerrordelay			10
 fetchpop3interval		15

--- a/cgi-bin/openwebmail/etc/openwebmail.conf.help
+++ b/cgi-bin/openwebmail/etc/openwebmail.conf.help
@@ -80,6 +80,7 @@ auth_pam_cobalt.pl	pam on cobalt	(pluggable authentication module)
 auth_pg.pl		postgres server (pgsql interface)
 auth_pgsql.pl		postgres server (DBI interface)
 auth_pop3.pl		remote pop3 server
+auth_imap.pl            remote imap server
 auth_unix.pl		unix passwd
 auth_unix_cobalt.pl	unix passwd	(optimized for Sun Cobalt servers)
 auth_vdomain.pl		passwd of vdomain on vmpop3d+postfix
@@ -1256,6 +1257,24 @@ authpop3_usessl
 -----------------------------------------------------------------------
 When auth_pop3.pl is used as authentication module, this option makes
 openwebmail use SSL to connect to auth pop3 server
+
+authimap_server
+-----------------------------------------------------------------------
+When auth_imap.pl is used as authentication module, this option specify
+the imap server for authentication
+Default: localhost
+
+authimap_port
+-----------------------------------------------------------------------
+When auth_imap.pl is used as authentication module, this option specify
+the port of the imap server for authentication
+Default: 143
+
+authimap_usessl
+-----------------------------------------------------------------------
+When auth_imap.pl is used as authentication module, this option makes
+openwebmail use SSL to connect to auth imap server
+
 
 
 loginerrordelay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - IMAP_HOST=${IMAP_HOST}
       - IMAP_PORT=${IMAP_PORT}
       - IMAP_SSL=${IMAP_SSL}
+      - IMAP_USER=${IMAP_USER}
+      - IMAP_PASSWORD=${IMAP_PASSWORD}
       - SMTP_HOST=${SMTP_HOST}
       - SMTP_PORT=${SMTP_PORT}
       - SMTP_USER=${SMTP_USER}


### PR DESCRIPTION
## Summary
- add `auth_imap.pl` module for remote IMAP logins
- document IMAP defaults in `openwebmail.conf` and help file
- add sample `auth_imap.conf`
- document IMAP environment variables in `.env.example` and compose file
- explain IMAP usage in README

## Testing
- `prove -l`