### PR TITLE
Expand HTML compose support to modern browsers

### DIFF
--- a/cgi-bin/openwebmail/openwebmail-abook.pl
+++ b/cgi-bin/openwebmail/openwebmail-abook.pl
@@ -4165,7 +4165,10 @@ sub HT_BINARYDATA {
 sub HT_ADR {
    my ($FIELD, $CHARSET) = HT_GENERIC(@_);
 
-   $FIELD->{enable_map} = cookie('ow-browserjavascript') eq 'dom' ? 1 : 0;
+   # mapping support requires JavaScript.  Accept 'dom' and 'ie' values set
+   # by the login page so all modern browsers are enabled instead of only
+   # Firefox.
+   $FIELD->{enable_map} = cookie('ow-browserjavascript') =~ /^(?:dom|ie)$/ ? 1 : 0;
 
    $FIELD->{mapquery} = join(',',
                               map { $FIELD->{$_} }

--- a/cgi-bin/openwebmail/openwebmail-send.pl
+++ b/cgi-bin/openwebmail/openwebmail-send.pl
@@ -188,7 +188,13 @@ sub compose {
    $attachments_uid =~ s#[<>@"'&;]##g;
 
    # get browser javascript support level (none,nn4,ie,dom)
-   my $enable_htmlcompose = cookie('ow-browserjavascript') eq 'dom' ? 1 : 0;
+   # allow HTML compose for any modern browser that supports JavaScript
+   # the login page sets the ow-browserjavascript cookie to 'dom' for
+   # standards compliant browsers and to 'ie' for older Internet Explorer.
+   # Previously only 'dom' (primarily Firefox) enabled the WYSIWYG editor.
+   # Expand support so 'ie' is also accepted which covers other modern
+   # browsers such as Chrome, Safari and Edge.
+   my $enable_htmlcompose = cookie('ow-browserjavascript') =~ /^(?:dom|ie)$/ ? 1 : 0;
 
    # force msgformat to text if html composing is not supported
    $msgformat = $newmsgformat = 'text' unless $enable_htmlcompose;


### PR DESCRIPTION
## Summary
- allow HTML compose on browsers identified as `dom` or `ie`
- allow address book maps when browser supports javascript

## Testing
- `prove -l`