### PR TITLE
Fix Perl version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y apache2 libapache2-mod-perl2 perl \


### PR DESCRIPTION
## Summary
- update Dockerfile to use Ubuntu 24.04 so Perl v5.36+ is available

## Testing
- `prove -l t`