### PR TITLE
Default root URL to OpenWebMail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
 RUN mkdir -p /usr/local/www/cgi-bin /usr/local/www/data
 COPY --chown=www-data:www-data cgi-bin/openwebmail /usr/local/www/cgi-bin/openwebmail
 COPY --chown=www-data:www-data data/openwebmail /usr/local/www/data/openwebmail
+COPY data/openwebmail/redirect.html /var/www/html/index.html
 
 # Ensure dbm configuration matches the DB_File modules shipped with Ubuntu
 # Without this adjustment, `openwebmail-tool.pl --init` fails asking for a

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker run -p 8080:80 openwebmail
 ```
 
 The application will then be available at
-`http://localhost:8080/openwebmail`.
+`http://localhost:8080/`.
 
 ### Docker Compose
 
@@ -99,7 +99,7 @@ Build and start the service with:
 docker-compose up --build
 ```
 
-The web interface will be available at `http://localhost:8080/openwebmail`.
+The web interface will be available at `http://localhost:8080/`.
 
 ## Links
 


### PR DESCRIPTION
## Summary
- redirect Apache document root to the OpenWebMail login page
- update README to reflect new root URL

## Testing
- `prove -lr t`