### PR TITLE
Enable dynamic auth module selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ SMTP_HOST=smtp.example.com
 SMTP_PORT=465
 SMTP_USER=username
 SMTP_PASSWORD=password
+AUTH_MODULE=auth_unix.pl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
+ARG AUTH_MODULE=auth_unix.pl
+ENV AUTH_MODULE=${AUTH_MODULE}
 RUN apt-get update && \
     apt-get install -y apache2 libapache2-mod-perl2 perl \
         libcgi-pm-perl libmime-base64-perl libnet-perl \
@@ -12,6 +14,8 @@ RUN mkdir -p /usr/local/www/cgi-bin /usr/local/www/data
 COPY --chown=www-data:www-data cgi-bin/openwebmail /usr/local/www/cgi-bin/openwebmail
 COPY --chown=www-data:www-data data/openwebmail /usr/local/www/data/openwebmail
 COPY data/openwebmail/redirect.html /var/www/html/index.html
+RUN sed -i "s/^auth_module.*/auth_module         ${AUTH_MODULE}/" \
+        /usr/local/www/cgi-bin/openwebmail/etc/openwebmail.conf
 
 # Ensure dbm configuration matches the DB_File modules shipped with Ubuntu
 # Without this adjustment, `openwebmail-tool.pl --init` fails asking for a

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The application will then be available at
 
 An example environment file is provided to make configuration easier. Copy
 `.env.example` to `.env` and adjust the values for your IMAP and SMTP server.
+You can also set `AUTH_MODULE` to select the authentication backend.
 
 Build and start the service with:
 

--- a/cgi-bin/openwebmail/openwebmail.pl
+++ b/cgi-bin/openwebmail/openwebmail.pl
@@ -228,6 +228,7 @@ sub loginmenu {
   # server type and host defaults from cookies
   my $server_type = param('server_type') || cookie('ow-server_type') || 'IMAP';
   my $server_host = param('server_host') || cookie('ow-server_host') || '';
+  my $auth_module = param('auth_module') || cookie('ow-auth_module') || $config{auth_module};
 
    # undef env to prevent httpprint() doing compression on login page
    delete $ENV{HTTP_ACCEPT_ENCODING} if (exists $ENV{HTTP_ACCEPT_ENCODING} && defined $ENV{HTTP_ACCEPT_ENCODING});
@@ -262,6 +263,7 @@ sub loginmenu {
                       use_httpcompression    => $use_httpcompression,
                       enable_autologin       => $enable_autologin,
                       use_autologin          => $use_autologin,
+                      auth_module            => $auth_module,
                       server_type            => $server_type,
                       server_host            => $server_host,
                       server_type_imap       => ($server_type eq 'IMAP' ? 1 : 0),
@@ -295,6 +297,7 @@ sub login {
    openwebmailerror(gettext('The following script must be setuid root to read the mail spools:') . " $0")
      if ($> != 0 && !$config{use_homedirspools} && ($config{mailspooldir} eq '/var/mail' || $config{mailspooldir} eq '/var/spool/mail'));
 
+   $config{auth_module} = param('auth_module') || cookie('ow-auth_module') || $config{auth_module};
    ow::auth::load($config{auth_module});
 
    # create domain logfile
@@ -664,6 +667,12 @@ sub login {
                            -path    => '/',
                            -expires => '+1M',
                         ));
+  push(@cookies, cookie(
+                           -name    => 'ow-auth_module',
+                           -value   => param('auth_module') || $config{auth_module},
+                           -path    => '/',
+                           -expires => '+1M',
+                        ));
   push(@header, -cookie=>\@cookies);
 
    # in case the javascript refresh does not work
@@ -772,6 +781,7 @@ sub autologin {
       read_owconf(\%config, \%config_raw, "$config{ow_sitesconfdir}/$logindomain");
    }
 
+   $config{auth_module} = param('auth_module') || cookie('ow-auth_module') || $config{auth_module};
    ow::auth::load($config{auth_module});
 
    ($domain, $user, $userrealname, $uuid, $ugid, $homedir) = get_domain_user_userinfo($logindomain, $loginuser);

--- a/data/openwebmail/layouts/classic/templates/login.tmpl
+++ b/data/openwebmail/layouts/classic/templates/login.tmpl
@@ -66,6 +66,10 @@
           <td align="right" nowrap>Servername:</td>
           <td><input type="text" name="server_host" size="<tmpl_var loginfieldwidth escape="html">" value="<tmpl_var server_host escape="html">"></td>
         </tr>
+        <tr>
+          <td align="right" nowrap>Auth Module:</td>
+          <td><input type="text" name="auth_module" size="<tmpl_var loginfieldwidth escape="html">" value="<tmpl_var auth_module escape="html"></td>
+        </tr>
 
         <tr>
           <td colspan="2">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - SMTP_PORT=${SMTP_PORT}
       - SMTP_USER=${SMTP_USER}
       - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - AUTH_MODULE=${AUTH_MODULE}
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- allow selecting auth module on login
- persist selected module via cookie
- expose `AUTH_MODULE` environment variable and Docker ARG
- document the new option

## Testing
- `prove -l t`
- `perl -T -c cgi-bin/openwebmail/openwebmail.pl` *(fails: Can't locate CGI.pm)*